### PR TITLE
Fixed git clone going wrong in install

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,7 @@
 define rbenv::install(
   $user  = $title,
   $group = $user,
-  $home  = "/home/$user",
+  $home  = "/home/${user}",
   $root  = "${home}/.rbenv",
 ) {
 


### PR DESCRIPTION
There was a small typo in the assignment of `$home`, that has been fixed and it seems to work like a charm. :)
