### PR TITLE
fix git clone of ruby-build

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -48,7 +48,7 @@ define rbenv::install(
   }
 
   exec { "rbenv::ruby-build ${user}":
-    command => "git clone git://github.com/sstephenson/ruby-build.git ${plugins}",
+    command => "git clone git://github.com/sstephenson/ruby-build.git ${plugins}/ruby-build",
     user    => $user,
     group   => $group,
     creates => "${plugins}/ruby-build",


### PR DESCRIPTION
The old command resulted in this:

```
git clone <URL> <root>/plugins
```

This cloned ruby-build _directly_ into `plugins/` dir and not
`plugins/ruby-build/`.
