### PR TITLE
Require rbenvgem provider with full path from rbenvgem type

### DIFF
--- a/lib/puppet/type/rbenvgem.rb
+++ b/lib/puppet/type/rbenvgem.rb
@@ -1,4 +1,5 @@
-require 'puppet/provider/rbenvgem' # Do not EVER forget the require when developing puppet types. -vjt
+provider_path = File.expand_path('../../provider/rbenvgem', __FILE__)
+require provider_path # Do not EVER forget the require when developing puppet types. -vjt
 
 Puppet.newtype(:rbenvgem) do
   @doc = "An RBenv gem"


### PR DESCRIPTION
This should get the `rbenvgem` provider to play well with vagrant
