### PR TITLE
Two fixes to help when installing to non-standard paths

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -23,6 +23,7 @@ define rbenv::install(
     creates => $root_path,
     path    => ['/usr/bin', '/usr/sbin'],
     timeout => 100,
+    cwd => $home_path,
     require => Package['git'],
   }
 
@@ -31,6 +32,7 @@ define rbenv::install(
     owner   => $user,
     group   => $group,
     content => template('rbenv/dot.rbenvrc.erb'),
+    require => Exec["rbenv::checkout ${user}"],
   }
 
   exec { "rbenv::bashrc ${user}":

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -34,6 +34,7 @@ define rbenv::plugin(
     creates => $destination,
     path    => ['/usr/bin', '/usr/sbin'],
     timeout => $timeout,
+    cwd => $home_path,
     require => File["rbenv::plugins ${user}"],
   }
 }


### PR DESCRIPTION
- The dependency chain in manifests/install.pp previously allowed the .bashrc and .rbenvrc files to be created even if installation failed. This patch fixes the following situation:

```
notice: /Stage[main]/Myrubyapp/Rbenv::Install[apps]/File[rbenv::rbenvrc apps]/ensure: defined content as '{md5}3c0d7cc5a836d399549a433fea1f15b3'
err: /Stage[main]/Myrubyapp/Rbenv::Install[apps]/Exec[rbenv::checkout apps]/returns: change from notrun to 0 failed...(error continues)
```

which leads to:

```
su - apps
-bash: rbenv: command not found
```
- Added cwd to execs to prevent git from dying with return code 128 when attempting to change back to a directory that the user does not have permission to access. This patch fixes the following situation:

```
err: /Stage[main]/Myrubyapp/Rbenv::Install[apps]/Exec[rbenv::checkout apps]/returns: change from notrun to 0 failed: git clone git://github.com/sstephenson/rbenv.git /opt/apps/.rbenv returned 128 instead of one of [0] at /etc/puppetlabs/puppet/modules/rbenv/manifests/install.pp:27
notice: /Stage[main]/Myrubyapp/Rbenv::Install[apps]/Exec[rbenv::checkout apps]/returns: fatal: Could not change back to '/root': Permission denied
```
