### PR TITLE
Fixes bundler gem install in environments with no pre-existing ruby interpreter

### DIFF
--- a/lib/puppet/provider/rbenvgem/default.rb
+++ b/lib/puppet/provider/rbenvgem/default.rb
@@ -29,9 +29,9 @@ Puppet::Type.type(:rbenvgem).provide :default do
       resource[:gemname]
     end
 
-    def gem(*args)
-      exe = resource[:rbenv] + '/bin/gem'
-      su('-', resource[:user], '-c', [exe, *args].join(' '))
+    def gem(*args)      
+      env = 'rbenv shell ' + resource[:ruby]
+      su('-', resource[:user], '-c', [env, 'gem', *args].join(' '))
     end
 
     def list(where = :local)

--- a/lib/puppet/type/rbenvgem.rb
+++ b/lib/puppet/type/rbenvgem.rb
@@ -47,8 +47,8 @@ Puppet::Type.newtype(:rbenvgem) do
     desc 'The Gem name'
   end
 
-  newparam(:rbenv) do
-    desc 'The rbenv root'
+  newparam(:ruby) do
+    desc 'The ruby interpreter'
   end
 
   newparam(:user) do

--- a/manifests/compile.pp
+++ b/manifests/compile.pp
@@ -86,8 +86,6 @@ define rbenv::compile(
     gem    => 'bundler',
     user   => $user,
     ruby   => $ruby,
-    home   => $home_path,
-    root   => $root_path,
   }
 
   # Set default global ruby version for rbenv, if requested

--- a/manifests/gem.pp
+++ b/manifests/gem.pp
@@ -4,15 +4,9 @@
 define rbenv::gem(
   $user,
   $ruby,
-  $gem    = $title,
-  $home   = '',
-  $root   = '',
+  $gem    = $title,  
   $ensure = present,
 ) {
-
-  # Workaround http://projects.puppetlabs.com/issues/9848
-  $home_path = $home ? { '' => "/home/${user}", default => $home }
-  $root_path = $root ? { '' => "${home_path}/.rbenv", default => $root }
 
   if ! defined( Exec["rbenv::compile ${user} ${ruby}"] ) {
     fail("Rbenv-Ruby ${ruby} for user ${user} not found in catalog")
@@ -21,8 +15,8 @@ define rbenv::gem(
   rbenvgem {"${user}/${ruby}/${gem}/${ensure}":
     ensure  => $ensure,
     user    => $user,
-    gemname => $gem,
-    rbenv   => "${root_path}/versions/${ruby}",
+    gemname => $gem,    
+    ruby => $ruby,    
     require => Exec["rbenv::compile ${user} ${ruby}"],
   }
 }


### PR DESCRIPTION
rbenv::compile failed to install bundler gem when used on a new user with no preexisting ruby installed. Tested with vagrant/centos6.3 (MRI & jruby).

So I tracked down the problem to the way the rbenvgem custom type tries to use the ruby's gem command. I think it should use rbenv for that. So, I worked around it by executing an "rbenv shell $ruby" before any gem command. 

Seems to work fine :)
