### PR TITLE
Make it possible to set MAKE_OPTS when compiling

### DIFF
--- a/manifests/compile.pp
+++ b/manifests/compile.pp
@@ -10,6 +10,7 @@ define rbenv::compile(
   $source = '',
   $global = false,
   $configure_opts = '--disable-install-doc',
+  $make_opts = '',
 ) {
 
   # Workaround http://projects.puppetlabs.com/issues/9848
@@ -61,7 +62,7 @@ define rbenv::compile(
     user        => $user,
     group       => $group,
     cwd         => $home_path,
-    environment => [ "HOME=${home_path}", "CONFIGURE_OPTS=${configure_opts}" ],
+    environment => [ "HOME=${home_path}", "CONFIGURE_OPTS=${configure_opts}", "MAKE_OPTS=${make_opts}" ],
     creates     => "${versions}/${ruby}",
     path        => $path,
     require     => Rbenv::Plugin["rbenv::plugin::rubybuild::${user}"],


### PR DESCRIPTION
This is useful if you want to set e.g. the number of jobs running simultaneously for speeding up the compilation process on multicore systems:

``` puppet
rbenv::compile { "1.9.3-p392":
  user      => $user,
  make_opts => "-j 5",
  ...
}
```
