### PR TITLE
Specify bundler version

### DIFF
--- a/manifests/compile.pp
+++ b/manifests/compile.pp
@@ -10,6 +10,7 @@ define rbenv::compile(
   $source         = '',
   $global         = false,
   $configure_opts = '--disable-install-doc',
+  $bundler        = present,
 ) {
 
   # Workaround http://projects.puppetlabs.com/issues/9848
@@ -81,6 +82,7 @@ define rbenv::compile(
   # Install bundler
   #
   rbenv::gem {"rbenv::bundler ${user} ${ruby}":
+    ensure => $bundler,
     user   => $user,
     ruby   => $ruby,
     gem    => 'bundler',

--- a/spec/defines/rbenv__compile_spec.rb
+++ b/spec/defines/rbenv__compile_spec.rb
@@ -5,7 +5,8 @@ describe 'rbenv::compile', :type => :define do
   let(:ruby_version) { '1.9.3-p125' }
   let(:title)        { "rbenv::compile::#{user}::#{ruby_version}" }
   let(:dot_rbenv)    { "/home/#{user}/.rbenv" }
-  let(:params)       { {:user => user, :ruby => ruby_version, :global => true} }
+  let(:bundler)      { '1.3.4' }
+  let(:params)       { {:user => user, :ruby => ruby_version, :global => true, :bundler => bundler} }
 
   it "installs ruby of the chosen version" do
     should contain_exec("rbenv::compile #{user} #{ruby_version}").
@@ -29,6 +30,6 @@ describe 'rbenv::compile', :type => :define do
 
   it "installs bundler" do
     should contain_rbenv__gem("rbenv::bundler #{user} #{ruby_version}").
-      with_ensure('present')
+      with_ensure(bundler)
   end
 end


### PR DESCRIPTION
This allows specifying an exact version of Bundler to install with a particular Ruby version:

``` puppet
rbenv::compile { "2.0.0-p0":
  user    => "lmars",
  bundler => "1.3.5"
}

rbenv::compile { "1.9.3-p194":
  user    => "lmars",
  bundler => "1.0.22"
}
```
