### PR TITLE
Add Linux to the osfamily dependencies, for the Amazon Linux AMI.

### DIFF
--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -1,8 +1,8 @@
 class rbenv::dependencies {
   case $::osfamily {
-    debian  : { require rbenv::dependencies::ubuntu }
-    redhat  : { require rbenv::dependencies::centos }
-    suse    : { require rbenv::dependencies::suse   }
-    default : { notice("Could not load dependencies for ${::osfamily}") }
+    debian         : { require rbenv::dependencies::ubuntu }
+    redhat, Linux  : { require rbenv::dependencies::centos }
+    suse           : { require rbenv::dependencies::suse   }
+    default        : { notice("Could not load dependencies for ${::osfamily}") }
   }
 }

--- a/spec/classes/dependencies_spec.rb
+++ b/spec/classes/dependencies_spec.rb
@@ -17,4 +17,9 @@ describe 'rbenv::dependencies' do
     let(:facts) { {:osfamily => 'suse'} }
     it { should include_class('rbenv::dependencies::suse') }
   end
+
+  context 'Amazon Linux' do
+    let(:facts) { {:osfamily => 'Linux'} }
+    it { should include_class('rbenv::dependencies::centos') }
+  end
 end


### PR DESCRIPTION
This will allow users to use rbenv on the default Amazon Linux AMI.
Come across this when trying to use the module for a project.
