### PR TITLE
Handle old Lenny distribution

### DIFF
--- a/manifests/dependencies/ubuntu.pp
+++ b/manifests/dependencies/ubuntu.pp
@@ -3,8 +3,16 @@ class rbenv::dependencies::ubuntu {
   if ! defined(Package['libc6-dev'])        { package { 'libc6-dev':        ensure => installed } }
   if ! defined(Package['bison'])            { package { 'bison':            ensure => installed } }
   if ! defined(Package['openssl'])          { package { 'openssl':          ensure => installed } }
-  if ! defined(Package['libreadline6'])     { package { 'libreadline6':     ensure => installed } }
-  if ! defined(Package['libreadline6-dev']) { package { 'libreadline6-dev': ensure => installed } }
+  case $::lsbdistcodename {
+    lenny: {
+      if ! defined(Package['libreadline5'])     { package { 'libreadline5':     ensure => installed } }
+      if ! defined(Package['libreadline5-dev']) { package { 'libreadline5-dev': ensure => installed } }
+    }
+    default : {
+      if ! defined(Package['libreadline6'])     { package { 'libreadline6':     ensure => installed } }
+      if ! defined(Package['libreadline6-dev']) { package { 'libreadline6-dev': ensure => installed } }
+    }
+  }
   if ! defined(Package['zlib1g'])           { package { 'zlib1g':           ensure => installed } }
   if ! defined(Package['zlib1g-dev'])       { package { 'zlib1g-dev':       ensure => installed } }
   if ! defined(Package['libssl-dev'])       { package { 'libssl-dev':       ensure => installed } }


### PR DESCRIPTION
Lenny doesn't have readline6 so downgrade to readline5.
