### PR TITLE
fixes an issue where the git clone exec resource was being called everytime

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -31,7 +31,7 @@ define rbenv::plugin(
     command => "git clone ${source} ${destination}",
     user    => $user,
     group   => $group,
-    creates => $destination,
+    unless => "test -d $destination",
     path    => ['/usr/bin', '/usr/sbin'],
     timeout => $timeout,
     cwd => $home_path,


### PR DESCRIPTION
For some reason when I used the rbenv::plugin, the creates parameter in this resource was not behaving correctly which caused errors when git clone is run.  Essentially, git refuses to clone the repo when the destination already exists.

The fix in the pull request essentially does the same thing as creates but actually works.

Error: git clone git://github.com/jamis/rbenv-gemset.git /var/www/.rbenv/plugins/rbenv-gemset  returned 128 instead of one of [0]

exec { "rbenv::plugin::checkout ${user} ${plugin_name}":
    command => "git clone ${source} ${destination}",
    user    => $user,
    group   => $group,
    creates => "$destination",
    path    => ['/usr/bin', '/usr/sbin'],
    timeout => $timeout,
    cwd => $home_path,
    require => File["rbenv::plugins ${user}"],
  }
