### PR TITLE
Add an Exec for updating rbenv plugins

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -39,9 +39,10 @@ define rbenv::plugin(
   }
 
   exec { "rbenv::plugin::update ${user} ${plugin_name}":
-    command => '/usr/bin/git pull',
+    command => 'git pull',
     user    => $user,
     group   => $group,
+    path    => ['/usr/bin', '/usr/sbin'],
     timeout => $timeout,
     cwd     => $destination,
     require => Exec["rbenv::plugin::checkout ${user} ${plugin_name}"],

--- a/spec/defines/rbenv__plugin_spec.rb
+++ b/spec/defines/rbenv__plugin_spec.rb
@@ -19,6 +19,15 @@ describe 'rbenv::plugin', :type => :define do
     )
   end
 
+  it 'pulls the latest plugin changes from their git repos' do
+    should contain_exec("rbenv::plugin::update #{user} #{plugin_name}").with(
+      :command => 'git pull',
+      :user    => user,
+      :cwd     => target_path,
+      :require => /rbenv::plugin::checkout #{user} #{plugin_name}/
+    )
+  end
+
   context 'with source != git' do
     let(:source) { 'something != git' }
 


### PR DESCRIPTION
This allows the ruby-build plugin to grab the latest ruby versions thus facilitating a version upgrade.
