### PR TITLE
Add logoutput => 'on_failure' to exec calls in compile stage.

### DIFF
--- a/manifests/compile.pp
+++ b/manifests/compile.pp
@@ -75,6 +75,7 @@ define rbenv::compile(
     environment => [ "HOME=${home_path}", "CONFIGURE_OPTS=${configure_opts}" ],
     creates     => "${versions}/${ruby}",
     path        => $path,
+    logoutput   => 'on_failure',
     require     => Rbenv::Plugin["rbenv::plugin::rubybuild::${user}"],
     before      => Exec["rbenv::rehash ${user} ${ruby}"],
   }
@@ -87,6 +88,7 @@ define rbenv::compile(
     onlyif      => "[ -e '${root_path}/.rehash' ]",
     environment => [ "HOME=${home_path}" ],
     path        => $path,
+    logoutput   => 'on_failure',
   }
 
   # Install bundler


### PR DESCRIPTION
When compiles fail, it is nice to get output describing why. This will log the exec's result if the compile fails.
