### PR TITLE
Explicitly set RBENV_ROOT

### DIFF
--- a/templates/dot.rbenvrc.erb
+++ b/templates/dot.rbenvrc.erb
@@ -4,5 +4,6 @@
 #
 if ! echo $PATH | grep -q rbenv; then
   export PATH="<%= @root_path %>/bin:$PATH"
+  export RBENV_ROOT="<%= @root_path %>"
   eval "$(rbenv init -)"
 fi


### PR DESCRIPTION
Set RBENV_ROOT so that 'rbenv init -' doesn't, as 'rbenv init -' assumes
RBENV_ROOT is in the user's home directory.

This enables the use of shared rbenvs.
