### PR TITLE
Fix line ending issues with templates.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
-# Set default behaviour, in case users don't have core.autocrlf set.
-* text=auto
-
-# Declare files that will always have LF line endings on checkout.
+# Template files should have UNIX style line endings
+# since they will most likely be run in a Linux
+# virtual machine.
 *.erb text eol=lf


### PR DESCRIPTION
It's likely that some users will be using Vagrant and a Windows guest to host Linux guest operating systems.

Many users who work in Windows have [configured git](https://help.github.com/articles/dealing-with-line-endings) to automatically deal with converting Unix style line endings to Windows style.

There are issues when the Linux guest is parsing provisioning scripts and templates that git has automatically converted to Windows style line endings.

A `.gitattributes` file can be set up to specifically prevent that conversion from happening with certain files or file extensions, for example: `*.erb`.

This pull request adds this setting to `.gitattributes`.
