### PR TITLE
binaries should be executable

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -28,6 +28,15 @@ define rbenv::install(
     require => Package['git'],
   }
 
+  file { "rbenv::dotrbenv perms":
+    path    => "$root_path/libexec",
+    recurse => true,
+    mode    => '0750',
+    owner   => $user,
+    group   => $group,
+    require => Exec["rbenv::checkout ${user}"],
+  }
+
   file { "rbenv::rbenvrc ${user}":
     path    => $rbenvrc,
     owner   => $user,


### PR DESCRIPTION
I had a problem upon a clean installation, the .rbenv/libexec would not be executable (0644 permissions).

Am I the only one to have this problem?

I made them '0750', through a folder, recursive. Tell me what you think that of solution.
