### PR TITLE
Support ruby compilation with piped patches

### DIFF
--- a/manifests/compile.pp
+++ b/manifests/compile.pp
@@ -8,6 +8,7 @@ define rbenv::compile(
   $home           = '',
   $root           = '',
   $source         = '',
+  $patch          = '',
   $global         = false,
   $keep           = false,
   $configure_opts = '--disable-install-doc',
@@ -31,6 +32,15 @@ define rbenv::compile(
   }
   else {
     $keep_flag = ''
+  }
+
+  if $patch {
+    $pipe_patch = "${patch} | "
+    $patch_flag = '--patch '
+  }
+  else {
+    $pipe_patch = ''
+    $patch_flag = ''
   }
 
   if ! defined( Class['rbenv::dependencies'] ) {
@@ -67,7 +77,7 @@ define rbenv::compile(
   # Set Timeout to disabled cause we need a lot of time to compile.
   # Use HOME variable and define PATH correctly.
   exec { "rbenv::compile ${user} ${ruby}":
-    command     => "rbenv install ${keep_flag}${ruby} && touch ${root_path}/.rehash",
+    command     => "${pipe_patch}rbenv install ${patch_flag}${keep_flag}${ruby} && touch ${root_path}/.rehash",
     timeout     => 0,
     user        => $user,
     group       => $group,


### PR DESCRIPTION
I just had to install an old Ruby `1.9.3-p448` on CentOS 6.4, however there is a known issue with compiling `2.0.0-p247` and lower on RedHat derivatives. See https://bugs.ruby-lang.org/issues/8384 for the issue. To do that, I needed to patch the Ruby, which I couldn't have done as easily with the current version.

If you checkout the [ruby-build wiki](https://github.com/sstephenson/ruby-build/wiki#troubleshooting), you can see other documented workarounds using the recently added `--patch` functionality of ruby-build, so I think its worth trying to support it.

While I'm not sure that this is the best interface for it, it seems flexible enough to support my (most?) use cases. I'm currently using it like this: 

``` puppet
rbenv::compile { '1.9.3-p448':
  # Its important to strip the changelog changes from the patch, as they
  # won't apply. It's the first file, that's why we're not taking it.
  patch => 'curl -fsSL https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/41808/diff?format=diff | filterdiff --files=2,3',
  user  => $user
}
```
