### PR TITLE
fix for rbenv::gem always running

### DIFF
--- a/lib/puppet/provider/rbenvgem/default.rb
+++ b/lib/puppet/provider/rbenvgem/default.rb
@@ -31,7 +31,7 @@ Puppet::Type.type(:rbenvgem).provide :default do
 
     def gem(*args)
       exe =  "RBENV_VERSION=#{resource[:ruby]} " + resource[:rbenv] + '/bin/gem'
-      su('-', resource[:user], '--', '-c', [exe, *args].join(' '))
+      su(resource[:user], '--', '-c', [exe, *args].join(' '))
     end
 
     def list(where = :local)


### PR DESCRIPTION
I've just added a -- to su. Without this, the --local option intended for gem list is instead applied to su, which results in a silent failure. Since the su returns non-zero, Puppet interprets this as needing to run rbenv::gem, which gets run during every Puppet apply regardless of whether the gem is already in place or not.
