### PR TITLE
change git pull" to use "git fetch && git reset --hard origin/master"

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -39,7 +39,7 @@ define rbenv::plugin(
   }
 
   exec { "rbenv::plugin::update ${user} ${plugin_name}":
-    command => 'git pull',
+    command => 'git fetch && git reset --hard origin/master',
     user    => $user,
     group   => $group,
     path    => ['/bin', '/usr/bin', '/usr/sbin'],

--- a/spec/defines/rbenv__plugin_spec.rb
+++ b/spec/defines/rbenv__plugin_spec.rb
@@ -22,7 +22,7 @@ describe 'rbenv::plugin', :type => :define do
 
   it 'pulls the latest plugin changes from their git repos' do
     should contain_exec("rbenv::plugin::update #{user} #{plugin_name}").with(
-      :command => 'git pull',
+      :command => 'git fetch && git reset --hard origin/master',
       :user    => user,
       :cwd     => target_path,
       :require => /rbenv::plugin::checkout #{user} #{plugin_name}/,


### PR DESCRIPTION
```
Debug: Exec[rbenv::plugin::update teamcity-agent ruby-build](provider=posix): Executing 'git pull'
Debug: Executing 'git pull'
Notice: /Stage[main]/Our_buildenv/Rbenv::Compile[1.9.3-p484]/Rbenv::Plugin::Rubybuild[rbenv::rubybuild::teamcity-agent]/Rbenv::Plugin[rbenv::plugin::rubybuild::teamcity-agent]/Exec[rbenv::plugin::update teamcity-agent ruby-build]/returns: 
Notice: /Stage[main]/Our_buildenv/Rbenv::Compile[1.9.3-p484]/Rbenv::Plugin::Rubybuild[rbenv::rubybuild::teamcity-agent]/Rbenv::Plugin[rbenv::plugin::rubybuild::teamcity-agent]/Exec[rbenv::plugin::update teamcity-agent ruby-build]/returns: *** Please tell me who you are.
Notice: /Stage[main]/Our_buildenv/Rbenv::Compile[1.9.3-p484]/Rbenv::Plugin::Rubybuild[rbenv::rubybuild::teamcity-agent]/Rbenv::Plugin[rbenv::plugin::rubybuild::teamcity-agent]/Exec[rbenv::plugin::update teamcity-agent ruby-build]/returns: 
Notice: /Stage[main]/Our_buildenv/Rbenv::Compile[1.9.3-p484]/Rbenv::Plugin::Rubybuild[rbenv::rubybuild::teamcity-agent]/Rbenv::Plugin[rbenv::plugin::rubybuild::teamcity-agent]/Exec[rbenv::plugin::update teamcity-agent ruby-build]/returns: Run
Notice: /Stage[main]/Our_buildenv/Rbenv::Compile[1.9.3-p484]/Rbenv::Plugin::Rubybuild[rbenv::rubybuild::teamcity-agent]/Rbenv::Plugin[rbenv::plugin::rubybuild::teamcity-agent]/Exec[rbenv::plugin::update teamcity-agent ruby-build]/returns: 
Notice: /Stage[main]/Our_buildenv/Rbenv::Compile[1.9.3-p484]/Rbenv::Plugin::Rubybuild[rbenv::rubybuild::teamcity-agent]/Rbenv::Plugin[rbenv::plugin::rubybuild::teamcity-agent]/Exec[rbenv::plugin::update teamcity-agent ruby-build]/returns:   git config --global user.email "you@example.com"
Notice: /Stage[main]/Our_buildenv/Rbenv::Compile[1.9.3-p484]/Rbenv::Plugin::Rubybuild[rbenv::rubybuild::teamcity-agent]/Rbenv::Plugin[rbenv::plugin::rubybuild::teamcity-agent]/Exec[rbenv::plugin::update teamcity-agent ruby-build]/returns:   git config --global user.name "Your Name"
Notice: /Stage[main]/Our_buildenv/Rbenv::Compile[1.9.3-p484]/Rbenv::Plugin::Rubybuild[rbenv::rubybuild::teamcity-agent]/Rbenv::Plugin[rbenv::plugin::rubybuild::teamcity-agent]/Exec[rbenv::plugin::update teamcity-agent ruby-build]/returns: 
Notice: /Stage[main]/Our_buildenv/Rbenv::Compile[1.9.3-p484]/Rbenv::Plugin::Rubybuild[rbenv::rubybuild::teamcity-agent]/Rbenv::Plugin[rbenv::plugin::rubybuild::teamcity-agent]/Exec[rbenv::plugin::update teamcity-agent ruby-build]/returns: to set your account's default identity.
Notice: /Stage[main]/Our_buildenv/Rbenv::Compile[1.9.3-p484]/Rbenv::Plugin::Rubybuild[rbenv::rubybuild::teamcity-agent]/Rbenv::Plugin[rbenv::plugin::rubybuild::teamcity-agent]/Exec[rbenv::plugin::update teamcity-agent ruby-build]/returns: Omit --global to set the identity only in this repository.
Notice: /Stage[main]/Our_buildenv/Rbenv::Compile[1.9.3-p484]/Rbenv::Plugin::Rubybuild[rbenv::rubybuild::teamcity-agent]/Rbenv::Plugin[rbenv::plugin::rubybuild::teamcity-agent]/Exec[rbenv::plugin::update teamcity-agent ruby-build]/returns: 
Notice: /Stage[main]/Our_buildenv/Rbenv::Compile[1.9.3-p484]/Rbenv::Plugin::Rubybuild[rbenv::rubybuild::teamcity-agent]/Rbenv::Plugin[rbenv::plugin::rubybuild::teamcity-agent]/Exec[rbenv::plugin::update teamcity-agent ruby-build]/returns: fatal: empty ident  <teamcity-agent@internal> not allowed
Error: git pull returned 128 instead of one of [0]
Error: /Stage[main]/Our_buildenv/Rbenv::Compile[1.9.3-p484]/Rbenv::Plugin::Rubybuild[rbenv::rubybuild::teamcity-agent]/Rbenv::Plugin[rbenv::plugin::rubybuild::teamcity-agent]/Exec[rbenv::plugin::update teamcity-agent ruby-build]/returns: change from notrun to 0 failed: git pull returned 128 instead of one of [0]
```