### PR TITLE
Updated the README.md Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 pkg/*
 tmp/*
 bin/*
+*.swp
+*swo

--- a/README.md
+++ b/README.md
@@ -15,14 +15,12 @@ In a nutshell, it supports the following conveniences:
 * Infrastructure to support rbenv plugins. We have already included [ruby-build](https://github.com/sstephenson/ruby-build) and [rbenv-vars](https://github.com/sstephenson/rbenv-vars) plugins.
 * Resource for handling `bundler`.
 
-## Rbenv installation
+## Rbenv Installation
 
 You can use the module in your manifest with the following code:
 
 ```
 rbenv::install { "someuser":
-  group => 'project',
-  home  => '/project'
 }
 ```
 
@@ -32,18 +30,32 @@ your taste, and pass the user on which install rbenv using the
 `user` parameter.
 
 The rbenv directory can be changed by passing the "root" parameter,
-that must be an absolute path.
+which must be an absolute path.
 
 ## Ruby compilation
 
 To compile a ruby interpreter, you use `rbenv::compile` as follows:
 
+### Standard Compile
+
 ```
 rbenv::compile { "1.9.3-p327":
   user => "someuser",
-  home => "/project",
 }
 ```
+
+### Compile with Configuration Options
+
+You may need to pass configuration options for particular operating systems or rubies.
+
+```
+rbenv::compile { "2.1.1":
+  user => "someuser",
+  configure_opts => '--with-readline-dir=/lib/x86_64-linux-gnu/libreadline.so.6.3'
+}
+```
+
+### Compile Multiple Rubies under Multiple Users
 
 The resource title is used as the ruby version, but if you have
 multiple rubies under multiple users, you'll have to define them
@@ -61,13 +73,23 @@ rbenv::compile { "bar/1.8.7":
 }
 ```
 
-`rbenv rehash` is performed each time a new ruby or a new gem is
-installed.
+### Compile with Global Option
 
 You can use the `global => true` parameter to set an interpreter as the
-default (`rbenv global`) one for the given user. Please note that only one global
-is allowed, duplicate resources will be defined if you specify
-multiple global ruby version.
+default (`rbenv global`) one for the given user. 
+
+```
+rbenv::compile { "1.9.3-p484":
+  user => "someuser",
+  global => true
+}
+```
+
+Please note that only one global is allowed---duplicate resources will be 
+defined if you specify multiple global ruby version.
+
+
+### Compile with Custom Source
 
 You can also provide a custom build definition to ruby-build by
 specifying a `source` that can either be a `puppet:` source or
@@ -76,10 +98,11 @@ a file to be downloaded using `wget`:
 ```
 rbenv::compile { "patched-ree":
   user   => "someuser",
-  home   => "/project",
   source => "puppet://path-to-definition"
 }
 ```
+
+### Compile but Keep Source
 
 If you're using debugger gems, you'll probably need to keep source tree after building.
 This is achieved by passing `keep => true` parameter.
@@ -91,6 +114,11 @@ rbenv::compile { "bar/1.8.7":
   keep => true,
 }
 ```
+
+## A Note about rbenv rehash
+
+`rbenv rehash` is performed each time a new ruby or a new gem is
+installed.
 
 ## Gem installation
 


### PR DESCRIPTION
Updated the README.md Documentation

Specifically, removed 'group' and 'home' parameters
from compile examples, as they do not seem necessary

Also, included an example with the 'configure_opts'
parameter, which is required to use Ruby 2.1.1
with Ubuntu 14.04.
