### PR TITLE
Allow adding elements to the ruby compile $PATH

### DIFF
--- a/manifests/compile.pp
+++ b/manifests/compile.pp
@@ -12,6 +12,7 @@ define rbenv::compile(
   $keep           = false,
   $configure_opts = '--disable-install-doc',
   $bundler        = present,
+  $compile_path   = [],
 ) {
 
   # Workaround http://projects.puppetlabs.com/issues/9848
@@ -22,7 +23,8 @@ define rbenv::compile(
   $shims       = "${root_path}/shims"
   $versions    = "${root_path}/versions"
   $global_path = "${root_path}/version"
-  $path        = [ $shims, $bin, '/bin', '/usr/bin' ]
+
+  $path        = [ $shims, $bin, '/bin', '/usr/bin', $compile_path ]
 
   # Keep flag saves source tree after building.
   # This is required for some gems (e.g. debugger)


### PR DESCRIPTION
When compiling Ruby 2.1.1 on a recent Mavericks system with Homebrew installed, it fails to compile because the openssl vendored into ruby seems to not compile. We've worked around this issue by installing openssl via homebrew, and then adjusting the `$PATH` to include `/usr/local/bin` (so the build can find the openssl configuration). This requires support from puppet-rbenv, since it sets a minimal `$PATH` that doesn't include `/usr/local/bin`. 

Does this seem like something you can include? If so, feel free to pull it in (-:
