### PR TITLE
Update plugins only if there is a newer version

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -46,6 +46,7 @@ define rbenv::plugin(
     timeout => $timeout,
     cwd     => $destination,
     require => Exec["rbenv::plugin::checkout ${user} ${plugin_name}"],
+    onlyif  => 'git remote update; if [ "$(git rev-parse @{0})" = "$(git rev-parse @{u})" ]; then return 0; else return 1; fi ]',
   }
 
 }

--- a/spec/defines/rbenv__plugin_spec.rb
+++ b/spec/defines/rbenv__plugin_spec.rb
@@ -26,7 +26,10 @@ describe 'rbenv::plugin', :type => :define do
       :user    => user,
       :cwd     => target_path,
       :require => /rbenv::plugin::checkout #{user} #{plugin_name}/,
-      :path    => ['/bin','/usr/bin','/usr/sbin']
+      :path    => ['/bin','/usr/bin','/usr/sbin'],
+      :onlyif  => 'git remote update; ' \
+                  'if [ "$(git rev-parse @{0})" = "$(git rev-parse @{u})" ]; ' \
+                  'then return 0; else return 1; fi ]'
     )
   end
 


### PR DESCRIPTION
A 'git pull' always generates a change event in Puppet even if there are
no changes in the upstream repository. This is bad for monitoring, for
example the puppet dashboard always shows all the plugins installed by
rbenv-puppet as changes for every run on every node.

This change makes sure that 'git pull' is only run when there is a new
version of the plugin upstream.