### PR TITLE
Fix rbenv automatic updates

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -46,7 +46,7 @@ define rbenv::plugin(
     timeout => $timeout,
     cwd     => $destination,
     require => Exec["rbenv::plugin::checkout ${user} ${plugin_name}"],
-    onlyif  => 'git remote update; if [ "$(git rev-parse @{0})" = "$(git rev-parse @{u})" ]; then return 0; else return 1; fi ]',
+    onlyif  => 'git remote update > /dev/null 2>&1; test `git rev-parse @{0}` != `git rev-parse @{u}`',
   }
 
 }

--- a/spec/defines/rbenv__plugin_spec.rb
+++ b/spec/defines/rbenv__plugin_spec.rb
@@ -27,9 +27,8 @@ describe 'rbenv::plugin', :type => :define do
       :cwd     => target_path,
       :require => /rbenv::plugin::checkout #{user} #{plugin_name}/,
       :path    => ['/bin','/usr/bin','/usr/sbin'],
-      :onlyif  => 'git remote update; ' \
-                  'if [ "$(git rev-parse @{0})" = "$(git rev-parse @{u})" ]; ' \
-                  'then return 0; else return 1; fi ]'
+      :onlyif  => 'git remote update > /dev/null 2>&1; ' \
+                  'test `git rev-parse @{0}` != `git rev-parse @{u}`'
     )
   end
 


### PR DESCRIPTION
Refs #112

The previous command would result in an error on the standard shell on
Ubuntu machines:

  sh: 1: Syntax error: word unexpected' "" ]'

Replace it with a more robust command that works in sh.
