### PR TITLE
Avoid Error on Exec resource without path attribute

### DIFF
--- a/manifests/definition.pp
+++ b/manifests/definition.pp
@@ -23,6 +23,7 @@ define rbenv::definition(
   } elsif $source =~ /http(s)?:/ {
     exec { "rbenv::definition-file ${user} ${ruby}":
       command => "wget ${source} -O ${destination}",
+      path    => '/usr/bin:/usr/sbin:/bin:/usr/local/bin',
       creates => $destination,
       user    => $user,
       require => Exec["rbenv::plugin::checkout ${user} ruby-build"],


### PR DESCRIPTION
When using rbenv::definition with source parameter and starting with /http(s)?:/, the exec resource needs to have path attribute to avoid Error "[...] is not qualified and no path was specified. Please qualify the command or specify a path."
