### PR TITLE
Pass cflags to compile

### DIFF
--- a/manifests/compile.pp
+++ b/manifests/compile.pp
@@ -11,6 +11,7 @@ define rbenv::compile(
   $global         = false,
   $keep           = false,
   $configure_opts = '--disable-install-doc',
+  $cflags         = '',
   $bundler        = present,
 ) {
 
@@ -72,7 +73,7 @@ define rbenv::compile(
     user        => $user,
     group       => $group,
     cwd         => $home_path,
-    environment => [ "HOME=${home_path}", "CONFIGURE_OPTS=${configure_opts}" ],
+    environment => [ "HOME=${home_path}", "CONFIGURE_OPTS=${configure_opts}", "CFLAGS=${cflags}" ],
     creates     => "${versions}/${ruby}",
     path        => $path,
     logoutput   => 'on_failure',


### PR DESCRIPTION
So that I can pass CFLAGS to avoid segfaults in ree-1.8.7-2012.02.

``` puppet
  rbenv::compile { 'ree-1.8.7-2012.02':
    configure_opts => '',
    cflags => '-O2 -fno-tree-dce -fno-optimize-sibling-calls',
    source => 'puppet:///.../patched-ree'
  }
```

Although I see another pull request for MAKE_OPTS. Maybe rather than adding all of these fields we should make environment more flexible.

PS: Thanks for the great module. :)
