### PR TITLE
Rehash rbenv after new gems are installed (fixes #91)

### DIFF
--- a/manifests/gem.pp
+++ b/manifests/gem.pp
@@ -27,5 +27,6 @@ define rbenv::gem(
     rbenv   => "${root_path}/versions/${ruby}",
     source  => $source,
     require => Exec["rbenv::compile ${user} ${ruby}"],
+    notify => Exec["rbenv::rehash ${user} ${ruby}"]
   }
 }


### PR DESCRIPTION
Adds a `notify` metaparameter to the `rbenvgem` function in puppet
manifest to ensure that a rehash of rbenv is performed when any gem is
installed
