### PR TITLE
Add timeout parameter to rbenvgem gem operations

### DIFF
--- a/lib/puppet/provider/rbenvgem/default.rb
+++ b/lib/puppet/provider/rbenvgem/default.rb
@@ -34,14 +34,16 @@ Puppet::Type.type(:rbenvgem).provide :default do
 
       exe  = "#{resource[:rbenv]}/bin/gem"
 
-      Puppet::Util::Execution.execute([exe, *args].join(' '),
-        :uid => user,
-        :failonfail => true,
-        :custom_environment => {
-          'HOME'          => home,
-          'RBENV_VERSION' => resource[:ruby],
-        }
-      )
+      Timeout::timeout(resource[:timeout], Timeout::Error) do
+        Puppet::Util::Execution.execute([exe, *args].join(' '),
+          :uid => user,
+          :failonfail => true,
+          :custom_environment => {
+            'HOME'          => home,
+            'RBENV_VERSION' => resource[:ruby],
+          }
+        )
+      end
     end
 
     def list(where = :local)

--- a/lib/puppet/type/rbenvgem.rb
+++ b/lib/puppet/type/rbenvgem.rb
@@ -63,4 +63,21 @@ Puppet::Type.newtype(:rbenvgem) do
     desc 'The gem source'
   end
 
+  newparam(:timeout) do
+    desc "Maximum time permitted for `gem` to execute.
+      Defaults to 300 seconds."
+
+    munge do |value|
+      value = value.shift if value.is_a?(Array)
+      begin
+        value = Float(value)
+      rescue ArgumentError
+        raise ArgumentError, "The timeout must be a number.", $!.backtrace
+      end
+      [value, 0.0].max
+    end
+
+    defaultto 300
+  end
+
 end

--- a/manifests/gem.pp
+++ b/manifests/gem.pp
@@ -4,11 +4,12 @@
 define rbenv::gem(
   $user,
   $ruby,
-  $gem    = $title,
-  $home   = '',
-  $root   = '',
-  $source = '',
-  $ensure = present
+  $gem     = $title,
+  $home    = '',
+  $root    = '',
+  $source  = '',
+  $ensure  = present,
+  $timeout = undef,
 ) {
 
   # Workaround http://projects.puppetlabs.com/issues/9848
@@ -26,6 +27,7 @@ define rbenv::gem(
     ruby    => $ruby,
     rbenv   => "${root_path}/versions/${ruby}",
     source  => $source,
+    timeout => $timeout,
     require => Exec["rbenv::compile ${user} ${ruby}"],
   }
 }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -46,7 +46,7 @@ define rbenv::plugin(
     timeout => $timeout,
     cwd     => $destination,
     require => Exec["rbenv::plugin::checkout ${user} ${plugin_name}"],
-    onlyif  => 'git remote update; if [ "$(git rev-parse @{0})" = "$(git rev-parse @{u})" ]; then return 0; else return 1; fi ]',
+    onlyif  => 'git remote update > /dev/null 2>&1; test `git rev-parse @{0}` != `git rev-parse @{u}`',
   }
 
 }

--- a/spec/defines/rbenv__plugin_spec.rb
+++ b/spec/defines/rbenv__plugin_spec.rb
@@ -27,9 +27,8 @@ describe 'rbenv::plugin', :type => :define do
       :cwd     => target_path,
       :require => /rbenv::plugin::checkout #{user} #{plugin_name}/,
       :path    => ['/bin','/usr/bin','/usr/sbin'],
-      :onlyif  => 'git remote update; ' \
-                  'if [ "$(git rev-parse @{0})" = "$(git rev-parse @{u})" ]; ' \
-                  'then return 0; else return 1; fi ]'
+      :onlyif  => 'git remote update > /dev/null 2>&1; ' \
+                  'test `git rev-parse @{0}` != `git rev-parse @{u}`'
     )
   end
 


### PR DESCRIPTION
There are some cases where installing certain gems (particularly ones that build native extensions) can take a **very** long time. This exposes a `timeout` parameter on the rbenvgem resources to permit end users to permit longer timeouts in those cases.
