### PR TITLE
Added support for creating multiple RC files

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,7 +3,7 @@ define rbenv::install(
   $group = $user,
   $home  = '',
   $root  = '',
-  $rc    = '.profile'
+  $rc    = ['.profile']
 ) {
 
   # Workaround http://projects.puppetlabs.com/issues/9848
@@ -35,14 +35,16 @@ define rbenv::install(
     content => template('rbenv/dot.rbenvrc.erb'),
     require => Exec["rbenv::checkout ${user}"],
   }
-
-  exec { "rbenv::shrc ${user}":
-    command => "echo 'source ${rbenvrc}' >> ${shrc}",
-    user    => $user,
-    group   => $group,
-    unless  => "grep -q rbenvrc ${shrc}",
-    path    => ['/bin', '/usr/bin', '/usr/sbin'],
-    require => File["rbenv::rbenvrc ${user}"],
+  $rc.each |$r| {
+    $rc_path = "${home_path}/${r}"
+    exec { "rbenv::shrc ${user}-${r}":
+      command => "echo 'source ${rbenvrc}' >> ${rc_path}",
+      user    => $user,
+      group   => $group,
+      unless  => "grep -q rbenvrc ${rc_path}",
+      path    => ['/bin', '/usr/bin', '/usr/sbin'],
+      require => File["rbenv::rbenvrc ${user}"],
+    }
   }
 
   file { "rbenv::cache-dir ${user}":


### PR DESCRIPTION
I had a situation when installing gitlab using sbadia/puppet-gitlab that I needed to create multiple RC files (I don't remember the reason) so I extended shrc file creation here.  

This uses the .each iterator that is part of the language now but may break backwards comparability, I don't have any older versions of puppet to test with.

I tried to run the spec tests to update those but they fail on the master branch as well so I am not sure whats up with that but master and this branch both had the same 17 failures.
