### PR TITLE
Add tmpdir option to rbenv::compile

### DIFF
--- a/manifests/compile.pp
+++ b/manifests/compile.pp
@@ -12,6 +12,7 @@ define rbenv::compile(
   $keep           = false,
   $configure_opts = '--disable-install-doc',
   $bundler        = present,
+  $tmpdir         = '',
 ) {
 
   # Workaround http://projects.puppetlabs.com/issues/9848
@@ -72,7 +73,7 @@ define rbenv::compile(
     user        => $user,
     group       => $group,
     cwd         => $home_path,
-    environment => [ "HOME=${home_path}", "CONFIGURE_OPTS=${configure_opts}" ],
+    environment => [ "HOME=${home_path}", "CONFIGURE_OPTS=${configure_opts}", "TMPDIR=${tmpdir}" ], 
     creates     => "${versions}/${ruby}",
     path        => $path,
     logoutput   => 'on_failure',


### PR DESCRIPTION
On systems with noexec on /tmp, it's useful to be able to set the TMPDIR environment variable inline
