### PR TITLE
Add Ubuntu 18 Support

### DIFF
--- a/manifests/dependencies.pp
+++ b/manifests/dependencies.pp
@@ -1,9 +1,9 @@
 class rbenv::dependencies {
-  case $::osfamily {
+  case $facts['os']['family'] {
     archlinux      : { require rbenv::dependencies::archlinux }
     debian         : { require rbenv::dependencies::ubuntu    }
     redhat, Linux  : { require rbenv::dependencies::centos    }
     suse           : { require rbenv::dependencies::suse      }
-    default        : { notice("Could not load dependencies for ${::osfamily}") }
+    default        : { notice("Could not load dependencies for ${facts['os']['family']}") }
   }
 }

--- a/manifests/dependencies/ubuntu.pp
+++ b/manifests/dependencies/ubuntu.pp
@@ -8,6 +8,10 @@ class rbenv::dependencies::ubuntu {
       if ! defined(Package['libreadline5'])     { package { 'libreadline5':     ensure => installed } }
       if ! defined(Package['libreadline5-dev']) { package { 'libreadline5-dev': ensure => installed } }
     }
+    bionic: {
+      if ! defined(Package['libreadline5'])     { package { 'libreadline7':     ensure => installed } }
+      if ! defined(Package['libreadline5-dev']) { package { 'libreadline7-dev': ensure => installed } }
+    }
     default : {
       if ! defined(Package['libreadline6'])     { package { 'libreadline6':     ensure => installed } }
       if ! defined(Package['libreadline6-dev']) { package { 'libreadline6-dev': ensure => installed } }

--- a/manifests/dependencies/ubuntu.pp
+++ b/manifests/dependencies/ubuntu.pp
@@ -10,7 +10,7 @@ class rbenv::dependencies::ubuntu {
     }
     bionic: {
       if ! defined(Package['libreadline7'])     { package { 'libreadline7':     ensure => installed } }
-      if ! defined(Package['libreadline7-dev']) { package { 'libreadline7-dev': ensure => installed } }
+      if ! defined(Package['libreadline7-dev']) { package { 'libreadline-dev': ensure => installed } }
     }
     default : {
       if ! defined(Package['libreadline6'])     { package { 'libreadline6':     ensure => installed } }

--- a/manifests/dependencies/ubuntu.pp
+++ b/manifests/dependencies/ubuntu.pp
@@ -12,6 +12,10 @@ class rbenv::dependencies::ubuntu {
       if ! defined(Package['libreadline7'])     { package { 'libreadline7':     ensure => installed } }
       if ! defined(Package['libreadline-dev'])  { package { 'libreadline-dev':  ensure => installed } }
     }
+    focal: {
+      if ! defined(Package['libreadline8'])     { package { 'libreadline8':     ensure => installed } }
+      if ! defined(Package['libreadline-dev'])  { package { 'libreadline-dev':  ensure => installed } }
+    }    
     default : {
       if ! defined(Package['libreadline6'])     { package { 'libreadline6':     ensure => installed } }
       if ! defined(Package['libreadline6-dev']) { package { 'libreadline6-dev': ensure => installed } }

--- a/manifests/dependencies/ubuntu.pp
+++ b/manifests/dependencies/ubuntu.pp
@@ -15,7 +15,11 @@ class rbenv::dependencies::ubuntu {
     focal: {
       if ! defined(Package['libreadline8'])     { package { 'libreadline8':     ensure => installed } }
       if ! defined(Package['libreadline-dev'])  { package { 'libreadline-dev':  ensure => installed } }
-    }    
+    }
+    jammy: {
+      if ! defined(Package['libreadline8'])     { package { 'libreadline8':     ensure => installed } }
+      if ! defined(Package['libreadline-dev'])  { package { 'libreadline-dev':  ensure => installed } }
+    }
     default : {
       if ! defined(Package['libreadline6'])     { package { 'libreadline6':     ensure => installed } }
       if ! defined(Package['libreadline6-dev']) { package { 'libreadline6-dev': ensure => installed } }

--- a/manifests/dependencies/ubuntu.pp
+++ b/manifests/dependencies/ubuntu.pp
@@ -9,8 +9,8 @@ class rbenv::dependencies::ubuntu {
       if ! defined(Package['libreadline5-dev']) { package { 'libreadline5-dev': ensure => installed } }
     }
     bionic: {
-      if ! defined(Package['libreadline5'])     { package { 'libreadline7':     ensure => installed } }
-      if ! defined(Package['libreadline5-dev']) { package { 'libreadline7-dev': ensure => installed } }
+      if ! defined(Package['libreadline7'])     { package { 'libreadline7':     ensure => installed } }
+      if ! defined(Package['libreadline7-dev']) { package { 'libreadline7-dev': ensure => installed } }
     }
     default : {
       if ! defined(Package['libreadline6'])     { package { 'libreadline6':     ensure => installed } }

--- a/manifests/dependencies/ubuntu.pp
+++ b/manifests/dependencies/ubuntu.pp
@@ -10,7 +10,7 @@ class rbenv::dependencies::ubuntu {
     }
     bionic: {
       if ! defined(Package['libreadline7'])     { package { 'libreadline7':     ensure => installed } }
-      if ! defined(Package['libreadline7-dev']) { package { 'libreadline-dev': ensure => installed } }
+      if ! defined(Package['libreadline-dev'])  { package { 'libreadline-dev':  ensure => installed } }
     }
     default : {
       if ! defined(Package['libreadline6'])     { package { 'libreadline6':     ensure => installed } }

--- a/manifests/dependencies/ubuntu.pp
+++ b/manifests/dependencies/ubuntu.pp
@@ -20,6 +20,10 @@ class rbenv::dependencies::ubuntu {
       if ! defined(Package['libreadline8'])     { package { 'libreadline8':     ensure => installed } }
       if ! defined(Package['libreadline-dev'])  { package { 'libreadline-dev':  ensure => installed } }
     }
+    noble: {
+      if ! defined(Package['libreadline8t64'])  { package { 'libreadline8t64':  ensure => installed } }
+      if ! defined(Package['libreadline-dev'])  { package { 'libreadline-dev':  ensure => installed } }
+    }
     default : {
       if ! defined(Package['libreadline6'])     { package { 'libreadline6':     ensure => installed } }
       if ! defined(Package['libreadline6-dev']) { package { 'libreadline6-dev': ensure => installed } }

--- a/manifests/dependencies/ubuntu.pp
+++ b/manifests/dependencies/ubuntu.pp
@@ -3,7 +3,7 @@ class rbenv::dependencies::ubuntu {
   if ! defined(Package['libc6-dev'])        { package { 'libc6-dev':        ensure => installed } }
   if ! defined(Package['bison'])            { package { 'bison':            ensure => installed } }
   if ! defined(Package['openssl'])          { package { 'openssl':          ensure => installed } }
-  case $::lsbdistcodename {
+  case $facts['os']['distro']['codename'] {
     lenny: {
       if ! defined(Package['libreadline5'])     { package { 'libreadline5':     ensure => installed } }
       if ! defined(Package['libreadline5-dev']) { package { 'libreadline5-dev': ensure => installed } }


### PR DESCRIPTION
libreadline6 isn't in the Ubuntu 18 repositories,  only libreadline7. This PR ensures that the module installs the correct libreadline version available for Ubuntu 18.